### PR TITLE
Allow display images via https

### DIFF
--- a/lib/alchemy/picture/cloudinary_url.rb
+++ b/lib/alchemy/picture/cloudinary_url.rb
@@ -4,7 +4,7 @@ module Alchemy
   module Picture::CloudinaryUrl
     def url(options = {})
       @options = options
-      image_file.remote_url(transformation: transformations)
+      image_file.remote_url(transformation: transformations, secure: !!options[:secure])
     end
 
     private


### PR DESCRIPTION
Pass `secure: true` to the `Alchemy::Picture#url` to serve images via https.